### PR TITLE
build: use c++14 for `less<>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ option(JSON11_BUILD_TESTS "Build unit tests" OFF)
 option(JSON11_ENABLE_DR1467_CANARY "Enable canary test for DR 1467" OFF)
 
 if(CMAKE_VERSION VERSION_LESS "3")
-  add_definitions(-std=c++11)
+  add_definitions(-std=c++14)
 else()
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CANARY_ARGS = -DJSON11_ENABLE_DR1467_CANARY=$(JSON11_ENABLE_DR1467_CANARY)
 endif
 
 test: json11.cpp json11.hpp test.cpp
-	$(CXX) $(CANARY_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
+	$(CXX) $(CANARY_ARGS) -O -std=c++14 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
 
 clean:
 	if [ -e test ]; then rm test; fi

--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ JSON values can have their values queried and inspected:
     std::string str = json[0]["k"].string_value();
 
 For more documentation see json11.hpp.
+
+NOTE: since this fork uses `std::less<>`, C++14 is required


### PR DESCRIPTION
Since `std::less<>` was added into source code after https://github.com/YI-DING/json11/commit/6ce95f6ce7a165de29839df0ae87b724bdc2aa03 , C++14 is required for omitting template argument. [ref](https://en.cppreference.com/w/cpp/utility/functional/less)

This PR updates Makefile and CMake to use C++14 instead, and also add a note to README for C++14 requirement.